### PR TITLE
FIx of concurrency problem and support inverted y values

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -52,7 +52,7 @@ const manager = async (
             return f
         })
         if (d !== undefined) {
-            db.put(z, x, y, d)
+            await db.put(z, x, y, d) 
             if (emptyTileSizes.every((a) => a !== d.length)) {
                 q.unshift(getTileChildren({ x, y, z }))
             }

--- a/src/tile.ts
+++ b/src/tile.ts
@@ -17,8 +17,11 @@ export const getTileURL = (
     y: number,
     z: number,
 ): string => {
+    const invertedY = (Math.pow(2, z) - 1) - y;
+
     return baseUrl
         .replace('{x}', x.toString())
         .replace('{y}', y.toString())
+        .replace('{-y}', invertedY.toString())
         .replace('{z}', z.toString())
 }


### PR DESCRIPTION
**Concurrency Issue Fix:** I've identified an issue where concurrent writes to the database could occur, leading to situations where the database becomes blocked. This problem was particularly evident in scenarios involving high concurrency levels, causing the "Database busy" error. To address this, I simply added an await on the write to the db, ensuring that only one write operation can proceed at a time. This change significantly improves the stability and reliability of under heavy load.

**Inverted Y-Value Support:** Furthermore, this PR introduces support for inverted Y-axis tile coordinates in addition to the above fix. This enhancement is crucial for compatibility with certain mapping standards that utilize an inverted Y-axis for tile numbering. To use, simply have {-y} instead of {y} in the url.

**Testing**:

Concurrency fix tested under high-load scenarios to ensure no "Database busy" errors occur.
Inverted Y-value support tested with map tiles from sources using both inverted Y-axis numbering schemes.

Thanks for the good work!

